### PR TITLE
adding support for reading parts of the IDAT for unencrypted files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,8 +3,10 @@ Package: illuminaio
 
 Version: 0.23.1-9000 [2018-07-18]
 
- o ...
-
+ o The readIDAT function gains a what argument for unencrypted IDAT files.
+   This allows the fast return of the number of 'nSNPsRead' (number of probes
+   in file) and 'IlluminaID' (probenames). This is to allow fast handling of
+   IDAT files in the minfi package.
 
 Version: 0.23.1 [2018-07-18]
 

--- a/R/readIDAT.R
+++ b/R/readIDAT.R
@@ -1,15 +1,15 @@
-readIDAT <- function(file) {
+readIDAT <- function(file, what = c("all", "IlluminaID", "nSNPsRead")) {
 
     ## Wrapper function to determine IDAT format and call appropriate reading routine.
     ## Currently this just checks the magic "IDAT" string and then reads the version number
     ## The file name is then passed and the file opened again by the read function.
-
+    
     stopifnot(is.character(file) || length(file) != 0)
     file <- path.expand(file)
     if(!file.exists(file)) {
         stop("Unable to find file ", file)
     }
-
+    
     if(grepl("\\.gz", file))
         con <- gzfile(file, "rb")
     else
@@ -17,25 +17,28 @@ readIDAT <- function(file) {
     on.exit({
         close(con)
     })
-
+    what <- match.arg(what)
+    
     ## Assert file format
     magic <- readChar(con, nchars=4)
     if (magic != "IDAT") {
         stop("Cannot read IDAT file. File format error. Unknown magic: ", magic)
     }
-
+    
     ## Read IDAT file format version
     version <- readBin(con, what="integer", size=4, n=1, signed = TRUE, endian = "little")
     
     if (version == 1) {
+        if(what != "all")
+            stop("This file is encrypted. For encrypted files we need `what` equal to `all`.")
         res <- readIDAT_enc(file)
     }
     else if (version == 3) {
-        res <- readIDAT_nonenc(file)
+        res <- readIDAT_nonenc(file, what = what)
     }
     else {
         stop("Cannot read IDAT file. Unsupported IDAT file format version: ", version)
     }
-        
+    
     return( res );
 }

--- a/R/readIDAT_nonenc.R
+++ b/R/readIDAT_nonenc.R
@@ -1,4 +1,4 @@
-readIDAT_nonenc <- function(file) {
+readIDAT_nonenc <- function(file, what = c("all", "IlluminaID", "nSNPsRead")) {
     readByte <- function(con, n=1, ...) {
         readBin(con, what="integer", n=n, size=1, endian="little", signed=FALSE)
     }
@@ -115,6 +115,7 @@ readIDAT_nonenc <- function(file) {
 
     if(! (is.character(file) || try(isOpen(file))))
         stop("argument 'file' needs to be either a character or an open, seekable connection")
+    what <- match.arg(what)
 
     if(is.character(file)) {
         stopifnot(length(file) == 1)
@@ -196,6 +197,14 @@ readIDAT_nonenc <- function(file) {
 
     seek(con, where=fields["nSNPsRead", "byteOffset"], origin="start")
     nSNPsRead <- readInt(con, n=1)
+    if(what == "nSNPsRead")
+        return(nSNPsRead)
+    if(what == "IlluminaID") {
+        where <- fields["IlluminaID", "byteOffset"]
+        seek(con, where = where, origin = "start")
+        res <- readField(con = con, field = "IlluminaID")
+        return(as.character(res))
+    }
 
     res <- rownames(fields)
     names(res) <- res

--- a/man/readIDAT.Rd
+++ b/man/readIDAT.Rd
@@ -8,11 +8,15 @@
 }
 
 \usage{
-readIDAT(file)
+readIDAT(file, what = c("all", "IlluminaID", "nSNPsRead"))
 }
 
 \arguments{
   \item{file}{character string specifying idat file to be read in.}
+  \item{what}{This allows the return of parts of the idat file, see
+  Value. This argument is only supported for non-encrypted idat files;
+  setting it to be different from default on an encrypted file throws an
+  error.}
 }
 
 \details{
@@ -30,6 +34,8 @@ readIDAT(file)
   file header and calling the appropriate reading routine internally.
 
   The function supports reading gzipped, unencrypted IDATs.
+
+  The use of the \code{what} argument is for package writers.
 }
 
 \value{
@@ -54,6 +60,11 @@ readIDAT(file)
   of the file and as such is not returned in the \code{Quants} entry.  Such
   fields will be placed here.  So far only the HumanHap550 v1 BeadChip has exhibited 
   this property.
+
+  In case \code{what} is set to \code{nSNPsRead} the function returns an
+  integer equal to this field.  In case \code{what} is set to
+  \code{IlluminaID} the function returns a character vector containing
+  the IDs.
 }
 
 \references{


### PR DESCRIPTION
See NEWS entry. This is not super general - it adds support for two modes of restricted reading that I need in minfi: (1) Just returning the number of "probes" in the IDAT file (called `nSNPsRead` in illuminaio/docs) (2) Just returning the probenames (called `IlluminaID`).