### PR TITLE
fix negative nRunInfoBlocks error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,4 +20,4 @@ License: GPL-2
 URL: https://github.com/HenrikBengtsson/illuminaio
 BugReports: https://github.com/HenrikBengtsson/illuminaio/issues
 biocViews: Infrastructure, DataImport, Microarray, ProprietaryPlatforms
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1

--- a/R/readIDAT_nonenc.R
+++ b/R/readIDAT_nonenc.R
@@ -72,7 +72,7 @@ readIDAT_nonenc <- function(file, what = c("all", "IlluminaID", "nSNPsRead")) {
         }
 
         ## Now read all bytes/characters
-        readChar(con, nchars=n)
+        readChar(con, nchars=n, useBytes=TRUE)
     }
 
     readField <- function(con, field) {
@@ -211,6 +211,7 @@ readIDAT_nonenc <- function(file, what = c("all", "IlluminaID", "nSNPsRead")) {
     names(res) <- res
     res <- res[order(fields[res, "byteOffset"])]
     res <- res[names(res) != "nSNPsRead"]
+    res <- res[c("IlluminaID", "SD", "Mean", "NBeads")] ## only these fields
     res <- lapply(res, function(xx) {
         where <- fields[xx, "byteOffset"]
         seek(con, where = where, origin = "start")

--- a/R/readIDAT_nonenc.R
+++ b/R/readIDAT_nonenc.R
@@ -98,7 +98,8 @@ readIDAT_nonenc <- function(file, what = c("all", "IlluminaID", "nSNPsRead")) {
                "Unknown.6" = readString(con = con),
                "Unknown.7" = readString(con = con),
                "RunInfo" = {
-                   nRunInfoBlocks <- readInt(con = con, n=1)
+                   ## make sure it's >= 0.
+                   nRunInfoBlocks <- max(0,readInt(con = con, n=1))
                    naValue <- as.character(NA)
                    RunInfo <- matrix(naValue, nrow=nRunInfoBlocks, ncol=5)
                    colnames(RunInfo) <- c("RunTime", "BlockType", "BlockPars",


### PR DESCRIPTION
Some IDAT gives negative number of blocks when gzipped (example: GSM4256802).

This fixes the following error:
matrix(naValue, nrow = nRunInfoBlocks, ncol = 5), invalid nrow value < 0